### PR TITLE
docs: "yarn add" instead of "yarn install"

### DIFF
--- a/packages/jsonld-lint-cli/README.md
+++ b/packages/jsonld-lint-cli/README.md
@@ -18,7 +18,7 @@ With your favorite package manager install
 With [yarn](https://yarnpkg.com/) run
 
 ```
-yarn install jsonld-lint-cli
+yarn add jsonld-lint-cli
 ```
 
 Or [npm](https://www.npmjs.com/) run


### PR DESCRIPTION
docs(jsonld-lint-cli): changes readme.md

"yarn add" instead of "yarn install", which has been deprecated



